### PR TITLE
Fixes to remove the need for to_s on everything off of the config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+# A sample Gemfile
+source "https://rubygems.org"
+
+gem "minitest"
+gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,12 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    minitest (3.3.0)
+    rake (0.9.2.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  minitest
+  rake

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,19 @@
+require 'bundler'
+Bundler::GemHelper.install_tasks
+
+require 'minitest/unit'
+
+desc 'Run all tests'
+task :test do
+  ENV['QUIET'] ||= 'true'
+
+  $LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__) + '/test'))
+  $LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__)))
+
+  MiniTest::Unit.autorun
+
+  test_files = Dir['test/**/*_test.rb']
+  test_files.each { |f| require f }
+end
+
+task :default => :test

--- a/lib/application_config.rb
+++ b/lib/application_config.rb
@@ -1,7 +1,8 @@
 require 'application_config/base'
 require 'application_config/data_structures/always_null_node'
 require 'application_config/data_structures/nested_hash'
-require 'application_config/data_structures/value_node'
+require 'application_config/data_structures/string_value_node'
+require 'application_config/data_structures/numeric_value_node'
 
 if defined?(Rails)
   require 'application_config/railtie'

--- a/lib/application_config/data_structures/nested_hash.rb
+++ b/lib/application_config/data_structures/nested_hash.rb
@@ -10,8 +10,16 @@ module ApplicationConfig
       def [](key)
         value = fetch(key, nil)
         return ApplicationConfig::DataStructures::AlwaysNullNode.new unless value
-        return ApplicationConfig::DataStructures::ValueNode.new(value) unless value.kind_of?(Hash)
-        return ApplicationConfig::DataStructures::NestedHash.new(value)
+        return ApplicationConfig::DataStructures::NestedHash.new(value) if value.kind_of?(Hash)
+
+        case value
+        when String
+          return ApplicationConfig::DataStructures::StringValueNode.new(value)
+        when Numeric
+          return ApplicationConfig::DataStructures::NumericValueNode.new(value)
+        else
+          raise "Unmapped value type: #{value.class.name} for #{value}"
+        end
       end
       
       def method_missing(method_name)

--- a/lib/application_config/data_structures/numeric_value_node.rb
+++ b/lib/application_config/data_structures/numeric_value_node.rb
@@ -1,0 +1,15 @@
+require 'delegate'
+module ApplicationConfig
+  module DataStructures
+    class NumericValueNode < DelegateClass(Numeric)
+
+      def [](key)
+        ApplicationConfig::DataStructures::AlwaysNullNode.new
+      end
+      
+      def method_missing(method_name)
+        return ApplicationConfig::DataStructures::AlwaysNullNode.new
+      end
+    end
+  end
+end

--- a/lib/application_config/data_structures/string_value_node.rb
+++ b/lib/application_config/data_structures/string_value_node.rb
@@ -1,7 +1,7 @@
 require 'forwardable'
 module ApplicationConfig
   module DataStructures
-    class ValueNode < String
+    class StringValueNode < String
       
       def [](key)
         ApplicationConfig::DataStructures::AlwaysNullNode.new

--- a/lib/application_config/data_structures/value_node.rb
+++ b/lib/application_config/data_structures/value_node.rb
@@ -1,13 +1,7 @@
 require 'forwardable'
 module ApplicationConfig
   module DataStructures
-    class ValueNode
-      extend Forwardable
-      def_delegators :@value, :eql?, :==, :to_s, :to_str, :to_i
-      
-      def initialize(value)
-        @value = value
-      end
+    class ValueNode < String
       
       def [](key)
         ApplicationConfig::DataStructures::AlwaysNullNode.new

--- a/test/app_config_test.rb
+++ b/test/app_config_test.rb
@@ -12,21 +12,21 @@ class AppConfigTest < MiniTest::Unit::TestCase
     ac = ApplicationConfig::Base.new
     ac.add("""node: value""")
 
-    assert_equal("value", ac.node)
+    assert("value" == ac.node, "expected #{"value"} to == #{ac.node}")
   end
 
   def test_root_value_node_equal_interpreted_string
     ac = ApplicationConfig::Base.new
     ac.add("""node: value""")
 
-    assert_equal("value", "#{ac.node}")
+    assert("value" == "#{ac.node}", "expected #{"value"} to == #{"#{ac.node}"}")
   end
 
   def test_root_value_node_equal_string_concat
     ac = ApplicationConfig::Base.new
     ac.add("""node: value""")
 
-    assert_equal("value", "" + ac.node)
+    assert("value" == "" + ac.node, "expected #{"value"} to == #{"" + ac.node}}")
   end
 
   def test_non_root_value_node_equal_string
@@ -37,7 +37,18 @@ root:
 """
     )
 
-    assert_equal("value", ac.root.node)
+    assert("value" == ac.root.node, "expected #{"value"} to == #{ac.root.node}")
+  end
+
+  def test_non_root_value_node_to_s_equal_to_string
+    ac = ApplicationConfig::Base.new
+    ac.add("""
+root:
+  node: value
+"""
+    )
+
+    assert_equal("value", ac.root.node.to_s)
   end
 
   def test_non_root_value_node_equal_interpreted_string
@@ -48,7 +59,7 @@ root:
 """
     )
 
-    assert_equal("value", "#{ac.root.node}")
+    assert("value" == "#{ac.root.node}", "expected #{"value"} to == #{"#{ac.root.node}"}")
   end
 
   def test_non_root_value_node_equal_string_concat
@@ -59,6 +70,6 @@ root:
 """
     )
 
-    assert_equal("value", "" + ac.root.node)
+    assert("value" == "" + ac.root.node, "expected #{"value"} to == #{"" + ac.root.node}")
   end
 end

--- a/test/app_config_test.rb
+++ b/test/app_config_test.rb
@@ -88,4 +88,28 @@ root:
       fail("Should have evaluated as string")
     end
   end
+
+  def test_non_root_value_node_fixnum_value
+    ac = ApplicationConfig::Base.new
+    ac.add("""
+root:
+  node: 5
+""")
+
+      assert_equal(5, ac.root.node)
+  end
+
+  def test_numeric_value_node_returns_null_node_on_missing_value
+    out = ApplicationConfig::DataStructures::NumericValueNode.new(5)
+    assert_equal(5, out)
+    assert_nil(out.monkeys)
+    assert_nil(out.monkeys.monkeys)
+  end
+
+  def test_string_value_node_returns_null_node_on_missing_value
+    out = ApplicationConfig::DataStructures::StringValueNode.new("hi")
+    assert_equal("hi", out)
+    assert_nil(out.monkeys)
+    assert_nil(out.monkeys.monkeys)
+  end
 end

--- a/test/app_config_test.rb
+++ b/test/app_config_test.rb
@@ -1,7 +1,31 @@
 require 'test_helper'
 
 class AppConfigTest < MiniTest::Unit::TestCase
-  def test_truth
-    assert true
+  def test_empty_config_allows_nils
+    ac = ApplicationConfig::Base.new
+
+    assert_not_NIL(ac.property)
+    assert_nil(ac.property)
+  end
+
+  def test_value_node_is_string
+    ac = ApplicationConfig::Base.new
+    ac.add("""key: value""")
+
+    assert_equal("value", ac.key)
+  end
+
+  def test_value_node_equal_intereted_string
+    ac = ApplicationConfig::Base.new
+    ac.add("""key: value""")
+
+    assert_equal("value", "#{ac.key}")
+  end
+
+  def test_value_node_equal_string_concat
+    ac = ApplicationConfig::Base.new
+    ac.add("""key: value""")
+    
+    assert_equal("value", "" + ac.key)
   end
 end

--- a/test/app_config_test.rb
+++ b/test/app_config_test.rb
@@ -72,4 +72,20 @@ root:
 
     assert("value" == "" + ac.root.node, "expected #{"value"} to == #{"" + ac.root.node}")
   end
+
+  def test_non_root_value_node_case_statement
+    ac = ApplicationConfig::Base.new
+    ac.add("""
+root:
+  node: value
+"""
+    )
+
+    case ac.root.node
+    when String
+      pass("Woot!")
+    else
+      fail("Should have evaluated as string")
+    end
+  end
 end

--- a/test/app_config_test.rb
+++ b/test/app_config_test.rb
@@ -1,8 +1,7 @@
 require 'test_helper'
 
-class AppConfigTest < ActiveSupport::TestCase
-  # Replace this with your real tests.
-  test "the truth" do
+class AppConfigTest < MiniTest::Unit::TestCase
+  def test_truth
     assert true
   end
 end

--- a/test/app_config_test.rb
+++ b/test/app_config_test.rb
@@ -8,24 +8,57 @@ class AppConfigTest < MiniTest::Unit::TestCase
     assert_nil(ac.property)
   end
 
-  def test_value_node_is_string
+  def test_root_value_node_equal_string
     ac = ApplicationConfig::Base.new
-    ac.add("""key: value""")
+    ac.add("""node: value""")
 
-    assert_equal("value", ac.key)
+    assert_equal("value", ac.node)
   end
 
-  def test_value_node_equal_intereted_string
+  def test_root_value_node_equal_interpreted_string
     ac = ApplicationConfig::Base.new
-    ac.add("""key: value""")
+    ac.add("""node: value""")
 
-    assert_equal("value", "#{ac.key}")
+    assert_equal("value", "#{ac.node}")
   end
 
-  def test_value_node_equal_string_concat
+  def test_root_value_node_equal_string_concat
     ac = ApplicationConfig::Base.new
-    ac.add("""key: value""")
-    
-    assert_equal("value", "" + ac.key)
+    ac.add("""node: value""")
+
+    assert_equal("value", "" + ac.node)
+  end
+
+  def test_non_root_value_node_equal_string
+    ac = ApplicationConfig::Base.new
+    ac.add("""
+root:
+  node: value
+"""
+    )
+
+    assert_equal("value", ac.root.node)
+  end
+
+  def test_non_root_value_node_equal_interpreted_string
+    ac = ApplicationConfig::Base.new
+    ac.add("""
+root:
+  node: value
+"""
+    )
+
+    assert_equal("value", "#{ac.root.node}")
+  end
+
+  def test_non_root_value_node_equal_string_concat
+    ac = ApplicationConfig::Base.new
+    ac.add("""
+root:
+  node: value
+"""
+    )
+
+    assert_equal("value", "" + ac.root.node)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,0 @@
-require 'rubygems'
-require 'active_support'
-require 'active_support/test_case'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,10 @@
+$:.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
+require 'application_config'
+
+class MiniTest::Unit::TestCase
+
+  def assert_not_NIL(test)
+    assert(test.class.name != "Nil", "expected #{test} to not be nil")
+  end
+
+end


### PR DESCRIPTION
Previously you had to do things like:

```
redirect_to ApplicationConfig::Base.google.url
```

Because the value nodes didn't represent as Strings or Numerics. This change allows you to stop doing that because value nodes now ARE the Numerics or Strings, but extended with the [] and method_missing magic that allows you to do:

```
assert_nil(ApplicationConfig::Base.null_key)
assert_nil(ApplicationConfig::Base.null_key.null_key)
assert_nil(ApplicationConfig::Base.null_key.null_key.null_key)
```

So this is a major improvement in the way things use to work.

This will also fix:

```
assert_equal(20, ApplicationConfig::Base.value_node_equal_5 + 15)
# and
assert_equal(20, 15 + ApplicationConfig::Base.value_node_equal_5)
```
